### PR TITLE
Fix: compatibility with realpath & improve script message readability

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 INSTALL_PATH="/usr/local/bin/epitest"
-SCRIPT_DIR=$(dirname "$(realpath "$0")")
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd -P )"
 
 if [ ! -f "$SCRIPT_DIR/epitest" ]; then
     echo "Error: 'epitest' script not found in the current directory."

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
 if [ "$(id -u)" -ne 0 ]; then
     echo "Error: You must run this script as root or with sudo."
     exit 1
@@ -14,7 +18,7 @@ if [ ! -f "$SCRIPT_DIR/epitest" ]; then
     exit 1
 fi
 
-echo "Installing 'epitest'..."
+echo -e "Installing 'epitest'...\n"
 
 cp -f "$SCRIPT_DIR/epitest" "$INSTALL_PATH" 2>/dev/null
 if [ $? -ne 0 ]; then
@@ -28,10 +32,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "'epitest' has been successfully installed (or overwritten)!"
+echo -e "'epitest' has been ${GREEN}successfully installed (or overwritten)${NC} !\n"
 echo "You can now run your project tests by using the following command:"
 echo "  epitest <command>"
 echo "Example: epitest ./a.out"
 echo
-echo "To uninstall, simply run: sudo rm /usr/local/bin/epitest"
-echo "and remove the 'epitest' script from this directory."
+echo -e "To uninstall, simply run: ${YELLOW}sudo rm /usr/local/bin/epitest${NC}"
+echo -e "and remove the 'epitest' script from this directory.\n"


### PR DESCRIPTION
**Changes**
- The **realpath** command is not available by default on all OS's and may require installation via coreutils (for example on macOS versions prior to 13). This ensures compatibility by using **basic commands** that are available on most unix based systems.
- Enhanced the readability of script messages.

For example : 
![image](https://github.com/user-attachments/assets/c158d415-74db-47c8-a3e1-21b3867cdbce)

After changes: 
<img src="https://github.com/user-attachments/assets/3fb93a27-1879-4675-b59f-1d38f5f38f7f" width="400">
